### PR TITLE
rtc(): add function to retrieve network time

### DIFF
--- a/csrc/g350.c
+++ b/csrc/g350.c
@@ -1297,7 +1297,63 @@ C_NATIVE(_g350_last_error){
     return ERR_OK;
 }
 
+int _g350_get_rtc(uint8_t* time)
+{
+    GSSlot* slot;
+    uint8_t* s0;
+    int l0;
+    int res;
+    slot = _gs_acquire_slot(GS_CMD_CCLK, NULL, 32, GS_TIMEOUT, 1);
+    _gs_send_at(GS_CMD_CCLK, "?");
+    _gs_wait_for_slot();
+    res = !slot->err;
+    if (res) {
+        if (_gs_parse_command_arguments(slot->resp, slot->eresp, "s", &s0, &l0) != 1) {
+            res = 0;
+        } else {
+            memcpy(time, s0 + 1, 20);
+        }
+    }
+    _gs_release_slot(slot);
 
+    return res;
+}
+
+/**
+ * @brief _g350_get_clock reads the real-time clock of the MT by means of +CCLK
+ *
+ *
+ */
+C_NATIVE(_g350_rtc){
+    C_NATIVE_UNWARN();
+    int err = ERR_OK;
+    uint8_t time[20];
+    *res = MAKE_NONE();
+    memset(time,0,20);
+    RELEASE_GIL();
+    if(!_g350_get_rtc(time)) err=ERR_RUNTIME_EXC;
+    ACQUIRE_GIL();
+    if (err==ERR_OK) {
+        PTuple* tpl = ptuple_new(7,NULL);
+        int yy,MM,dd,hh,mm,ss,tz;
+        yy = 2000+((time[0]-'0')*10+(time[1]-'0'));
+        MM = (time[3]-'0')*10+(time[4]-'0');
+        dd = (time[6]-'0')*10+(time[7]-'0');
+        hh = (time[9]-'0')*10+(time[10]-'0');
+        mm = (time[12]-'0')*10+(time[13]-'0');
+        ss = (time[15]-'0')*10+(time[16]-'0');
+        tz = ((time[18]-'0')*10+(time[19]-'0'))*15*((time[17]=='-')?-1:1);
+        PTUPLE_SET_ITEM(tpl,0,PSMALLINT_NEW(yy));
+        PTUPLE_SET_ITEM(tpl,1,PSMALLINT_NEW(MM));
+        PTUPLE_SET_ITEM(tpl,2,PSMALLINT_NEW(dd));
+        PTUPLE_SET_ITEM(tpl,3,PSMALLINT_NEW(hh));
+        PTUPLE_SET_ITEM(tpl,4,PSMALLINT_NEW(mm));
+        PTUPLE_SET_ITEM(tpl,5,PSMALLINT_NEW(ss));
+        PTUPLE_SET_ITEM(tpl,6,PSMALLINT_NEW(tz));
+        *res = tpl;
+    }
+    return err;
+}
 
 /**
  * @brief _g350_rssi return the signal strength as reported by +CIEV urc

--- a/csrc/g350.h
+++ b/csrc/g350.h
@@ -127,46 +127,48 @@ typedef struct _gsm_status{
 
 
 #define GS_CMD_CCID             0
-#define GS_CMD_CGATT            1
-#define GS_CMD_CGED             2
-#define GS_CMD_CGSN             3
-#define GS_CMD_CIEV             4
-#define GS_CMD_CMEE             5
-#define GS_CMD_CMER             6
-#define GS_CMD_COPS             7
-#define GS_CMD_CREG             8
-#define GS_CMD_IPR              9
-#define GS_CMD_UDCONF           10
-#define GS_CMD_UDNSRN           11
-#define GS_CMD_UPSD             12
-#define GS_CMD_UPSDA            13
-#define GS_CMD_UPSND            14
-#define GS_CMD_URAT             15
-#define GS_CMD_USECMNG          16
-#define GS_CMD_USECPRF          17
-#define GS_CMD_USOCL            18
-#define GS_CMD_USOCO            19
-#define GS_CMD_USOCR            20
-#define GS_CMD_USOCTL           21
-#define GS_CMD_USOGO            22
-#define GS_CMD_USOLI            23
-#define GS_CMD_USORD            24
-#define GS_CMD_USORF            25
-#define GS_CMD_USOSEC           26
-#define GS_CMD_USOSO            27
-#define GS_CMD_USOST            28
-#define GS_CMD_USOWR            29
-#define GS_CMD_UUPSDA           30
-#define GS_CMD_UUPSDD           31
-#define GS_CMD_UUSOCL           32
-#define GS_CMD_UUSOLI           33
-#define GS_CMD_UUSORD           34
-#define GS_CMD_UUSORF           35
+#define GS_CMD_CCLK             1
+#define GS_CMD_CGATT            2
+#define GS_CMD_CGED             3
+#define GS_CMD_CGSN             4
+#define GS_CMD_CIEV             5
+#define GS_CMD_CMEE             6
+#define GS_CMD_CMER             7
+#define GS_CMD_COPS             8
+#define GS_CMD_CREG             9
+#define GS_CMD_IPR              10
+#define GS_CMD_UDCONF           11
+#define GS_CMD_UDNSRN           12
+#define GS_CMD_UPSD             13
+#define GS_CMD_UPSDA            14
+#define GS_CMD_UPSND            15
+#define GS_CMD_URAT             16
+#define GS_CMD_USECMNG          17
+#define GS_CMD_USECPRF          18
+#define GS_CMD_USOCL            19
+#define GS_CMD_USOCO            20
+#define GS_CMD_USOCR            21
+#define GS_CMD_USOCTL           22
+#define GS_CMD_USOGO            23
+#define GS_CMD_USOLI            24
+#define GS_CMD_USORD            25
+#define GS_CMD_USORF            26
+#define GS_CMD_USOSEC           27
+#define GS_CMD_USOSO            28
+#define GS_CMD_USOST            29
+#define GS_CMD_USOWR            30
+#define GS_CMD_UUPSDA           31
+#define GS_CMD_UUPSDD           32
+#define GS_CMD_UUSOCL           33
+#define GS_CMD_UUSOLI           34
+#define GS_CMD_UUSORD           35
+#define GS_CMD_UUSORF           36
 #define GS_GET_CMD(cmdid) (&gs_commands[cmdid])
 
 static const GSCmd gs_commands[] = {
 
     DEF_CMD("+CCID",      GS_RES_OK, GS_CMD_NORMAL , GS_CMD_CCID),
+    DEF_CMD("+CCLK",      GS_RES_OK, GS_CMD_NORMAL , GS_CMD_CCLK),
     DEF_CMD("+CGATT",     GS_RES_OK, GS_CMD_NORMAL , GS_CMD_CGATT),
     DEF_CMD("+CGED",      GS_RES_OK, GS_CMD_NORMAL , GS_CMD_CGED),
     DEF_CMD("+CGSN",      GS_RES_NO, GS_CMD_NORMAL , GS_CMD_CGSN),

--- a/g350.py
+++ b/g350.py
@@ -105,6 +105,33 @@ def last_error():
     """
     pass
 
+@native_c("_g350_rtc",["csrc/g350.c"])
+def rtc():
+    """
+------------
+Network Time
+------------
+
+The UG96 has an internal Real Time Clock that is automatically synchronized with the Network Time.
+The current time can be retrieved with the following function:
+
+.. function:: rtc()
+
+    Return a tuple of seven elements:
+
+        * current year
+        * current month (1-12)
+        * current day (1-31)
+        * current hour (0-23)
+        * current minute (0-59)
+        * current second (0-59)
+        * current timezone in minutes away from GMT 0
+
+    The returned time is always UTC time with a timezone indication.
+
+    """
+    pass
+
 @c_native("_g350_rssi",["csrc/g350.c"])
 def rssi():
     pass


### PR DESCRIPTION
This patch implements the `rtc()` method for u-blox G350 module, proposed by https://github.com/zerynth/core-zerynth-stdlib/pull/2.